### PR TITLE
get page by index not label

### DIFF
--- a/pdf2svg.c
+++ b/pdf2svg.c
@@ -156,7 +156,8 @@ int main(int argn, char *args[])
 			free(svgFilenameBuffer);
 		}
 		else {
-			page = poppler_document_get_page_by_label(pdffile, pageLabel);
+			//get by page index instead of label
+			page = poppler_document_get_page(pdffile, atoi(pageLabel));
 			conversionErrors = convertPage(page, svgFilename);
 			g_free(pageLabel);
 		}


### PR DESCRIPTION
some pdfs don’t start at “page 1”. To mitigate this we will always use the index